### PR TITLE
Fix issue #2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS = -O3 -Wall $(shell gimptool-2.0 --cflags && pkg-config --cflags lensfun 
 LIBS = $(shell gimptool-2.0 --libs && pkg-config --libs lensfun exiv2)
 PLUGIN = gimplensfun
 SOURCES = src/gimplensfun.c
-CC = /usr/bin/g++-4.4
+CC = g++
 # LD = gcc-4.4
 # END CONFIG ##################################################################
 

--- a/src/gimplensfun.c
+++ b/src/gimplensfun.c
@@ -1075,9 +1075,10 @@ run (const gchar*   name,
         ldb->Load ();
 
         // read exif data
-        if (read_opts_from_exif(gimp_image_get_filename(imageID))!=0) {
-            printf("No Exif data found");
-        }
+        const gchar *filename = gimp_image_get_filename(imageID);
+
+        if ((filename != NULL) && (read_opts_from_exif(filename) != 0))
+            g_print("No Exif data found");
 
         /* Display the dialog */
         if (! create_dialog_window (drawable))


### PR DESCRIPTION
Without loading or saving an image, gimp_image_get_filename() returns NULL that
breaks the string constructor. It is easily fixed by not loading the Exif data.
