### PR TITLE
Makefile flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-CFLAGS = -O3 -Wall $(shell gimptool-2.0 --cflags && pkg-config --cflags lensfun exiv2) -fopenmp 
+CXXFLAGS ?= -O3
+CXXFLAGS += -Wall $(shell gimptool-2.0 --cflags && pkg-config --cflags lensfun exiv2) -fopenmp
 LIBS = $(shell gimptool-2.0 --libs && pkg-config --libs lensfun exiv2)
 PLUGIN = gimplensfun
 SOURCES = src/gimplensfun.c
-CC = g++
+CXX ?= g++
 # LD = gcc-4.4
 # END CONFIG ##################################################################
 
@@ -13,10 +14,10 @@ all: $(PLUGIN)
 OBJECTS = $(subst .c,.o,$(SOURCES))
 
 $(PLUGIN): $(OBJECTS)
-	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ $(LDFLAGS) $(LIBS)
 
 %.o: %.c $(HEADERS)
-	$(CC) $(CFLAGS) -c -o $@ $*.c
+	$(CXX) $(CXXFLAGS) -c -o $@ $*.c
 	
 install: $(PLUGIN)
 	@gimptool-2.0 --install-admin-bin $^


### PR DESCRIPTION
compiler should be g++ hence use CXX and CXXFLAGS variables

CXXFLAGS ?= -O3
will only apply if the system/env has no CXXFLAGS set which is desirable, cause source distros handle these flags internally and don't want Makefiles to overwrite them. Same for CXX ?= g++
CXXFLAGS +=
will just append stuff to the current CXXFLAGS

LDFLAGS were missing from the linker line
