### PR TITLE
Compilation now acts as expected, also introduces EXTRA_CXXFLAGS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,11 @@ endif
 
 # set standard values, if not set by default
 CXX ?= g++
-CXXFLAGS += -O3
+CXXFLAGS += -O3 -Wall
 
 
 # project-specific flags
-CXXFLAGS += -Wall $(shell gimptool-2.0 --cflags && pkg-config --cflags lensfun exiv2)
+EXTRA_CXXFLAGS += $(shell gimptool-2.0 --cflags && pkg-config --cflags lensfun exiv2)
 LDFLAGS += $(shell gimptool-2.0 --libs && pkg-config --libs lensfun exiv2) -lstdc++
 
 
@@ -47,8 +47,8 @@ OBJECTS = $(subst .cpp,.o,$(SOURCES))
 $(PLUGIN): $(OBJECTS)
 	$(CXX) -o $@ $^ $(LDFLAGS)
 
-%.o: %.c $(HEADERS)
-	$(CXX) $(CXXFLAGS) -c -o $@ $*.c
+%.o: %.cpp $(HEADERS)
+	$(CXX) $(CXXFLAGS) $(EXTRA_CXXFLAGS) -c -o $@ $*.cpp
 
 install: $(PLUGIN)
 	@gimptool-2.0 --install-admin-bin $^


### PR DESCRIPTION
Fix compilation of object file by changing .c suffixes to .cpp suffixes so make actually runs our target to build the object file rather than its own default target.  Also introduce EXTRA_CXXFLAGS for project specific settings that should _always_ be included in a build but allows CXXFLAGS to be overridden at build time e.g. make CXXFLAGS="my preferred compile options"

The EXTRA_CXXFLAGS is important to get gimp-lensfun included in Fedora (see https://bugzilla.redhat.com/show_bug.cgi?id=951496 and probably other distributions).  They enforce C and C++ programs to be built with a standard set of options by running something like:
  make CXXFLAGS="%{optflags}" 
This uses a macro to expand the standard Fedora compile options but with this patch now allows this override to take place successfully as we're still including essential options in the EXTRA_FLAGS.

Hope that makes sense?!?!?!? 
