### PR TITLE
fix sony lens detection + fix compilation issue with latest liblensfun

### DIFF
--- a/src/gimplensfun.cpp
+++ b/src/gimplensfun.cpp
@@ -297,7 +297,6 @@ static void PrintLens (const lfLens *lens)
     g_print ("\tFocal: %g-%g\n", lens->MinFocal, lens->MaxFocal);
     g_print ("\tAperture: %g-%g\n", lens->MinAperture, lens->MaxAperture);
     g_print ("\tCenter: %g,%g\n", lens->CenterX, lens->CenterY);
-    g_print ("\tCCI: %g/%g/%g\n", lens->RedCCI, lens->GreenCCI, lens->BlueCCI);
     if (lens->Mounts)
         for (int j = 0; lens->Mounts [j]; j++)
             g_print ("\tMount: %s\n", lf_db_mount_name (ldb, lens->Mounts [j]));
@@ -1096,7 +1095,7 @@ static int read_opts_from_exif(const char *filename) {
         MakerNoteKey = "Exif.OlympusEq.LensType";
     }
     if ((CamMaker.find("sony"))!=string::npos) {
-        //MakerNoteKey = "Exif.Sony1.LensID";
+        MakerNoteKey = "Exif.Photo.LensModel";
     }
 
     //Decode Lens ID


### PR DESCRIPTION
1. Fix sony lens detection.
    Tested with Sony NEX3.

2. Fix compilation error due to lensfun commit:
  Author: da_seeb <da_seeb@2a61fa91-e63d-0410-b60c-e65103854af9>
  Date:   Sun Feb 2 18:02:01 2014 +0000

     Patch #3533: Remove support for CCI